### PR TITLE
ci: migrate to centralized workflows and Knope versioning

### DIFF
--- a/.git-town.toml
+++ b/.git-town.toml
@@ -1,0 +1,20 @@
+# See https://www.git-town.com/configuration-file for details
+
+[branches]
+main = "develop"
+
+[create]
+share-new-branches = "no"
+
+[hosting]
+forge-type = "github"
+github-connector = "gh"
+
+[ship]
+delete-tracking-branch = true
+
+[sync]
+feature-strategy = "rebase"
+perennial-strategy = "rebase"
+push-hook = true
+upstream = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: Build
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    uses: LumeWeb/workflows/.github/workflows/build-plugin.yml@develop
+    with:
+      additional_dependencies: go.lumeweb.com/portal-plugin-core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: LumeWeb/workflows/.github/workflows/release.yml@develop
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/update-ui.yml
+++ b/.github/workflows/update-ui.yml
@@ -1,0 +1,19 @@
+name: Update UI
+
+on:
+  repository_dispatch:
+    types: [update-ui]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  call-workflow:
+    uses: LumeWeb/workflows/.github/workflows/update-ui.yml@develop
+    with:
+      commit_hash: ${{ github.event.client_payload.commit_hash }}
+      app_name: ${{ github.event.client_payload.app_name }}
+      repository: ${{ github.event.client_payload.repository }}
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 # Go workspace file
 go.work

--- a/knope.toml
+++ b/knope.toml
@@ -1,0 +1,7 @@
+[package]
+versioned_files = ["go.mod"]
+changelog = "CHANGELOG.md"
+
+[github]
+owner = "LumeWeb"
+repo = "portal-plugin-admin"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request migrates the repository's CI/CD infrastructure to centralized workflows and introduces Knope for automated versioning. It adds GitHub Actions configurations for build, release, and UI update processes that reference shared workflows from `LumeWeb/workflows`. Additionally, it implements Knope configuration to manage versioning via `go.mod` and changelog generation. The changes also include setting up Git Town for branch management and updating `.gitignore` to exclude the vendor directory.
<!-- kody-pr-summary:end -->