### PR TITLE
ci: add secrets inherit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,3 +11,4 @@ jobs:
     uses: LumeWeb/workflows/.github/workflows/build-plugin.yml@develop
     with:
       additional_dependencies: go.lumeweb.com/portal-plugin-core
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,5 +9,4 @@ permissions:
 jobs:
   release:
     uses: LumeWeb/workflows/.github/workflows/release.yml@develop
-    secrets:
-      PAT: ${{ secrets.PAT }}
+    secrets: inherit

--- a/.github/workflows/update-ui.yml
+++ b/.github/workflows/update-ui.yml
@@ -15,5 +15,4 @@ jobs:
       commit_hash: ${{ github.event.client_payload.commit_hash }}
       app_name: ${{ github.event.client_payload.app_name }}
       repository: ${{ github.event.client_payload.repository }}
-    secrets:
-      PAT: ${{ secrets.PAT }}
+    secrets: inherit


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the GitHub Actions workflow configurations to streamline secret management. It modifies the `build`, `release`, and `update-ui` workflows to utilize the `secrets: inherit` directive. This change automatically passes all available repository secrets to the reusable workflows, removing the need to explicitly specify individual secrets such as the Personal Access Token (PAT).
<!-- kody-pr-summary:end -->