### PR TITLE
feat: add shared secret auth for pprof endpoints

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -15,6 +15,7 @@ import (
 	"go.lumeweb.com/portal-middleware/auth/jwt"
 	"go.lumeweb.com/portal-plugin-admin/internal"
 	pluginConfig "go.lumeweb.com/portal-plugin-admin/internal/config"
+	pluginMw "go.lumeweb.com/portal-plugin-admin/internal/api/middleware"
 	router "go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
@@ -44,10 +45,18 @@ func (a *API) Subdomain() string {
 func (a *API) Configure(r router.Router, accessSvc core.AccessService) error {
 	router.MustDefaultStaticSetup(r, router.NewAppFilesystem(portal_admin.GetFS(), router.AppFilesystemConfig{Domain: a.Config().Config().Core.Domain}))
 
-	authMw := middleware.AuthMiddleware(a.Context(), middleware.WithAuthPurpose(jwt.PurposeLogin))
+	apiCfg := core.GetAPIConfig[pluginConfig.APIConfig](a.Context(), internal.PLUGIN_NAME)
+
+	var authMw echo.MiddlewareFunc
+	if apiCfg.PprofSecret != "" {
+		a.Logger().Info("pprof shared secret auth enabled")
+		authMw = pluginMw.PprofSharedSecretAuth(&apiCfg)
+	} else {
+		authMw = middleware.AuthMiddleware(a.Context(), middleware.WithAuthPurpose(jwt.PurposeLogin))
+	}
 	accessMw := middleware.AccessMiddleware(a.Context())
 
-	routes := a.buildPprofRoutes(authMw, accessMw)
+	routes := a.buildPprofRoutes(authMw, accessMw, apiCfg.PprofSecret != "")
 	if err := router.RegisterRoutes(r, accessSvc, a.Subdomain(), routes); err != nil {
 		return fmt.Errorf("failed to register pprof routes: %w", err)
 	}
@@ -75,141 +84,148 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 	return api, nil, nil
 }
 
-func (a *API) buildPprofRoutes(authMw, accessMw echo.MiddlewareFunc) []router.Route {
+func (a *API) buildPprofRoutes(authMw, accessMw echo.MiddlewareFunc, sharedSecretEnabled bool) []router.Route {
+	applyAuth := func(route ...router.RouteOption) []router.RouteOption {
+		if sharedSecretEnabled {
+			return append(route, router.WithMiddlewares(authMw))
+		}
+		return append(route, router.WithAccess(core.ACCESS_ADMIN_ROLE), router.WithMiddlewares(authMw, accessMw))
+	}
+
 	return []router.Route{
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/", a.pprofIndex,
-			router.WithSwaggerOptions(
-				router.WithSummary("pprof index"),
-				router.WithDescription("Returns a page listing available pprof profiles."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "HTML index of available profiles"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("pprof index"),
+					router.WithDescription("Returns a page listing available pprof profiles."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "HTML index of available profiles"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/profile", a.pprofProfile,
-			router.WithSwaggerOptions(
-				router.WithSummary("CPU profile"),
-				router.WithDescription("Returns a CPU profile for the specified duration. Supports 'seconds' and 'debug' query parameters."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "CPU profile data"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("CPU profile"),
+					router.WithDescription("Returns a CPU profile for the specified duration. Supports 'seconds' and 'debug' query parameters."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "CPU profile data"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/trace", a.pprofTrace,
-			router.WithSwaggerOptions(
-				router.WithSummary("Execution trace"),
-				router.WithDescription("Returns an execution trace. Supports 'seconds' query parameter."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "Execution trace data"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Execution trace"),
+					router.WithDescription("Returns an execution trace. Supports 'seconds' query parameter."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "Execution trace data"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/cmdline", a.pprofCmdline,
-			router.WithSwaggerOptions(
-				router.WithSummary("Command line"),
-				router.WithDescription("Returns the command line of the running program."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "Command line output"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Command line"),
+					router.WithDescription("Returns the command line of the running program."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "Command line output"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/symbol", a.pprofSymbol,
-			router.WithSwaggerOptions(
-				router.WithSummary("Symbol lookup"),
-				router.WithDescription("Looks up program counters and returns function names."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "Symbol lookup results"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Symbol lookup"),
+					router.WithDescription("Looks up program counters and returns function names."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "Symbol lookup results"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/goroutine", a.pprofGoroutine,
-			router.WithSwaggerOptions(
-				router.WithSummary("Goroutine profile"),
-				router.WithDescription("Returns stack traces of all current goroutines."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "Goroutine profile data"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Goroutine profile"),
+					router.WithDescription("Returns stack traces of all current goroutines."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "Goroutine profile data"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/heap", a.pprofHeap,
-			router.WithSwaggerOptions(
-				router.WithSummary("Heap profile"),
-				router.WithDescription("Returns a sampling of memory allocations."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "Heap profile data"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Heap profile"),
+					router.WithDescription("Returns a sampling of memory allocations."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "Heap profile data"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/threadcreate", a.pprofThreadcreate,
-			router.WithSwaggerOptions(
-				router.WithSummary("Thread creation profile"),
-				router.WithDescription("Returns stack traces that led to the creation of new OS threads."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "Thread creation profile data"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Thread creation profile"),
+					router.WithDescription("Returns stack traces that led to the creation of new OS threads."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "Thread creation profile data"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/block", a.pprofBlock,
-			router.WithSwaggerOptions(
-				router.WithSummary("Block profile"),
-				router.WithDescription("Returns stack traces that led to blocking on synchronization primitives."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "Block profile data"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Block profile"),
+					router.WithDescription("Returns stack traces that led to blocking on synchronization primitives."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "Block profile data"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/mutex", a.pprofMutex,
-			router.WithSwaggerOptions(
-				router.WithSummary("Mutex profile"),
-				router.WithDescription("Returns stack traces of holders of contended mutexes."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "Mutex profile data"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Mutex profile"),
+					router.WithDescription("Returns stack traces of holders of contended mutexes."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "Mutex profile data"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodGet, "/api/debug/pprof/status", a.pprofStatus,
-			router.WithSwaggerOptions(
-				router.WithSummary("Profiling status"),
-				router.WithDescription("Returns the current block and mutex profiling rates."),
-				router.WithTags("Profiling"),
-				router.WithSuccessResponse(http.StatusOK, "Current profiling status",
-					router.WithJSONContent(ProfilingStatusResponse{}),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Profiling status"),
+					router.WithDescription("Returns the current block and mutex profiling rates."),
+					router.WithTags("Profiling"),
+					router.WithSuccessResponse(http.StatusOK, "Current profiling status",
+						router.WithJSONContent(ProfilingStatusResponse{}),
+					),
 				),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			)...,
 		),
 		router.NewRoute(http.MethodPut, "/api/debug/pprof/block", a.pprofBlockUpdate,
-			router.WithSwaggerOptions(
-				router.WithSummary("Set block profile rate"),
-				router.WithDescription("Sets the block profiling rate. 0 disables, 1 captures all, higher values sample."),
-				router.WithTags("Profiling"),
-				router.WithRequestBody(BlockProfileRequest{}, "Block profile rate", true),
-				router.WithSuccessResponse(http.StatusNoContent, "Block profile rate updated"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Set block profile rate"),
+					router.WithDescription("Sets the block profiling rate. 0 disables, 1 captures all, higher values sample."),
+					router.WithTags("Profiling"),
+					router.WithRequestBody(BlockProfileRequest{}, "Block profile rate", true),
+					router.WithSuccessResponse(http.StatusNoContent, "Block profile rate updated"),
+				),
+			)...,
 		),
 		router.NewRoute(http.MethodPut, "/api/debug/pprof/mutex", a.pprofMutexUpdate,
-			router.WithSwaggerOptions(
-				router.WithSummary("Set mutex profile fraction"),
-				router.WithDescription("Sets the mutex profiling fraction. 0 disables, 1 captures all, 100 samples 1%."),
-				router.WithTags("Profiling"),
-				router.WithRequestBody(MutexProfileRequest{}, "Mutex profile fraction", true),
-				router.WithSuccessResponse(http.StatusNoContent, "Mutex profile fraction updated"),
-			),
-			router.WithAccess(core.ACCESS_ADMIN_ROLE),
-			router.WithMiddlewares(authMw, accessMw),
+			applyAuth(
+				router.WithSwaggerOptions(
+					router.WithSummary("Set mutex profile fraction"),
+					router.WithDescription("Sets the mutex profiling fraction. 0 disables, 1 captures all, 100 samples 1%."),
+					router.WithTags("Profiling"),
+					router.WithRequestBody(MutexProfileRequest{}, "Mutex profile fraction", true),
+					router.WithSuccessResponse(http.StatusNoContent, "Mutex profile fraction updated"),
+				),
+			)...,
 		),
 	}
 }

--- a/internal/api/middleware/pprof_auth.go
+++ b/internal/api/middleware/pprof_auth.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	pluginConfig "go.lumeweb.com/portal-plugin-admin/internal/config"
+)
+
+// PprofSharedSecretAuth validates a request using a shared secret
+// provided as a Bearer token in the Authorization header.
+// If PprofSecret is empty in config, the middleware is a pass-through.
+func PprofSharedSecretAuth(cfg *pluginConfig.APIConfig) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			configuredSecret := cfg.PprofSecret
+
+			if configuredSecret == "" {
+				return next(c)
+			}
+
+			providedSecret := extractBearerToken(c)
+
+			if providedSecret == "" {
+				return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+					"error": "Unauthorized: missing pprof secret",
+				})
+			}
+
+			if subtle.ConstantTimeCompare([]byte(providedSecret), []byte(configuredSecret)) != 1 {
+				return c.JSON(http.StatusUnauthorized, map[string]interface{}{
+					"error": "Unauthorized: invalid pprof secret",
+				})
+			}
+
+			return next(c)
+		}
+	}
+}
+
+func extractBearerToken(c echo.Context) string {
+	authHeader := c.Request().Header.Get("Authorization")
+	if strings.HasPrefix(authHeader, "Bearer ") {
+		return strings.TrimPrefix(authHeader, "Bearer ")
+	}
+	return ""
+}

--- a/internal/api/middleware/pprof_auth_test.go
+++ b/internal/api/middleware/pprof_auth_test.go
@@ -1,0 +1,112 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	pluginConfig "go.lumeweb.com/portal-plugin-admin/internal/config"
+)
+
+func TestPprofSharedSecretAuth_ValidBearerToken(t *testing.T) {
+	e := echo.New()
+	cfg := &pluginConfig.APIConfig{PprofSecret: "test-secret"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/pprof/", nil)
+	req.Header.Set("Authorization", "Bearer test-secret")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := PprofSharedSecretAuth(cfg)(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err := handler(c)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestPprofSharedSecretAuth_InvalidSecret(t *testing.T) {
+	e := echo.New()
+	cfg := &pluginConfig.APIConfig{PprofSecret: "test-secret"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/pprof/", nil)
+	req.Header.Set("Authorization", "Bearer wrong-secret")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := PprofSharedSecretAuth(cfg)(func(c echo.Context) error {
+		t.Fatal("handler should not be called")
+		return nil
+	})
+
+	_ = handler(c)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestPprofSharedSecretAuth_MissingSecret(t *testing.T) {
+	e := echo.New()
+	cfg := &pluginConfig.APIConfig{PprofSecret: "test-secret"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/pprof/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := PprofSharedSecretAuth(cfg)(func(c echo.Context) error {
+		t.Fatal("handler should not be called")
+		return nil
+	})
+
+	_ = handler(c)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestPprofSharedSecretAuth_EmptyConfigSecret_Disabled(t *testing.T) {
+	e := echo.New()
+	cfg := &pluginConfig.APIConfig{PprofSecret: ""}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/pprof/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := PprofSharedSecretAuth(cfg)(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err := handler(c)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestPprofSharedSecretAuth_NoBearerPrefix(t *testing.T) {
+	e := echo.New()
+	cfg := &pluginConfig.APIConfig{PprofSecret: "test-secret"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/pprof/", nil)
+	req.Header.Set("Authorization", "test-secret")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := PprofSharedSecretAuth(cfg)(func(c echo.Context) error {
+		t.Fatal("handler should not be called")
+		return nil
+	})
+
+	_ = handler(c)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,15 @@
 package config
 
 type APIConfig struct {
+	// PprofSecret is an optional shared secret for authenticating pprof
+	// endpoints as an alternative to JWT-based admin auth. When set,
+	// requests must provide the secret as a Bearer token in the
+	// Authorization header.
+	PprofSecret string `config:"pprof_secret"`
 }
 
 func (A APIConfig) Defaults() map[string]any {
-	return map[string]any{}
+	return map[string]any{
+		"PprofSecret": "",
+	}
 }


### PR DESCRIPTION
## Summary

- Add `PprofSharedSecretAuth` middleware that validates requests using a Bearer token in the `Authorization` header against a configured shared secret
- When `pprof_secret` is set in the admin API config, pprof routes use the shared secret middleware instead of JWT + admin role access middleware
- When `pprof_secret` is empty, behavior is unchanged (JWT auth + admin role access)

## Config

Set `pprof_secret` under the admin API config to enable shared secret auth for pprof endpoints.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/api/middleware/ -v` (5 tests covering valid token, invalid token, missing token, empty config, no Bearer prefix)

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR adds an optional shared secret authentication mechanism for pprof (profiling) endpoints, providing an alternative to the existing JWT-based admin authentication.

### Changes

- **New config option (`pprof_secret`)**: Added a `PprofSecret` field to the admin plugin's `APIConfig`. When configured, pprof endpoints authenticate via a shared secret instead of JWT-based admin auth.

- **New middleware (`PprofSharedSecretAuth`)**: Validates requests by extracting a Bearer token from the `Authorization` header and comparing it against the configured secret using constant-time comparison. When no secret is configured, the middleware is a pass-through.

- **Conditional auth strategy**: The API configuration logic now checks whether `PprofSecret` is set. If set, pprof routes use only the shared secret middleware (bypassing the admin role access check). If not set, routes retain the original behavior requiring JWT login auth and admin role access.

- **Tests**: Added comprehensive tests covering valid tokens, invalid secrets, missing secrets, disabled mode (empty config), and missing Bearer prefix.

### Purpose

This allows external profiling tools (e.g., `go tool pprof`) to access pprof endpoints using a simple shared secret, without requiring a full admin login session. When the secret is not configured, the existing JWT-based admin authentication remains in effect.
<!-- kody-pr-summary:end -->