### PR TITLE
feat: add /api/internal/pprof endpoint with shared secret auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/Oudwins/zog v0.22.0
 	github.com/labstack/echo/v4 v4.15.1
+	github.com/samber/lo v1.52.0
 	github.com/stretchr/testify v1.11.1
 	go.lumeweb.com/httputil v0.5.4
 	go.lumeweb.com/portal v0.4.2-0.20260204232917-ecd0f81a80f1
@@ -146,7 +147,6 @@ require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect
-	github.com/samber/lo v1.52.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	pprofhttp "net/http/pprof"
 
+	"github.com/samber/lo"
 	"go.lumeweb.com/httputil"
 	"go.lumeweb.com/portal-middleware/middleware"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
@@ -45,20 +46,21 @@ func (a *API) Subdomain() string {
 func (a *API) Configure(r router.Router, accessSvc core.AccessService) error {
 	router.MustDefaultStaticSetup(r, router.NewAppFilesystem(portal_admin.GetFS(), router.AppFilesystemConfig{Domain: a.Config().Config().Core.Domain}))
 
-	apiCfg := core.GetAPIConfig[*pluginConfig.APIConfig](a.Context(), internal.PLUGIN_NAME)
-
-	var authMw echo.MiddlewareFunc
-	if apiCfg.PprofSecret != "" {
-		a.Logger().Info("pprof shared secret auth enabled")
-		authMw = pluginMw.PprofSharedSecretAuth(apiCfg)
-	} else {
-		authMw = middleware.AuthMiddleware(a.Context(), middleware.WithAuthPurpose(jwt.PurposeLogin))
-	}
+	authMw := middleware.AuthMiddleware(a.Context(), middleware.WithAuthPurpose(jwt.PurposeLogin))
 	accessMw := middleware.AccessMiddleware(a.Context())
 
-	routes := a.buildPprofRoutes(authMw, accessMw, apiCfg.PprofSecret != "")
+	routes := a.buildPprofRoutes(authMw, accessMw)
 	if err := router.RegisterRoutes(r, accessSvc, a.Subdomain(), routes); err != nil {
 		return fmt.Errorf("failed to register pprof routes: %w", err)
+	}
+
+	apiCfg := core.GetAPIConfig[*pluginConfig.APIConfig](a.Context(), internal.PLUGIN_NAME)
+	if apiCfg.PprofSecret != "" {
+		a.Logger().Info("internal pprof shared secret auth enabled")
+		internalRoutes := a.buildInternalPprofRoutes(pluginMw.PprofSharedSecretAuth(apiCfg))
+		if err := router.RegisterRoutes(r, accessSvc, a.Subdomain(), internalRoutes); err != nil {
+			return fmt.Errorf("failed to register internal pprof routes: %w", err)
+		}
 	}
 
 	return nil
@@ -84,11 +86,8 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 	return api, nil, nil
 }
 
-func (a *API) buildPprofRoutes(authMw, accessMw echo.MiddlewareFunc, sharedSecretEnabled bool) []router.Route {
+func (a *API) buildPprofRoutes(authMw, accessMw echo.MiddlewareFunc) []router.Route {
 	applyAuth := func(route ...router.RouteOption) []router.RouteOption {
-		if sharedSecretEnabled {
-			return append(route, router.WithMiddlewares(authMw))
-		}
 		return append(route, router.WithAccess(core.ACCESS_ADMIN_ROLE), router.WithMiddlewares(authMw, accessMw))
 	}
 
@@ -228,6 +227,32 @@ func (a *API) buildPprofRoutes(authMw, accessMw echo.MiddlewareFunc, sharedSecre
 			)...,
 		),
 	}
+}
+
+func (a *API) buildInternalPprofRoutes(authMw echo.MiddlewareFunc) []router.Route {
+	routes := []struct {
+		path    string
+		handler echo.HandlerFunc
+	}{
+		{"/api/internal/pprof/cmdline", a.pprofCmdline},
+		{"/api/internal/pprof/symbol", a.pprofSymbol},
+		{"/api/internal/pprof/goroutine", a.pprofGoroutine},
+		{"/api/internal/pprof/heap", a.pprofHeap},
+		{"/api/internal/pprof/threadcreate", a.pprofThreadcreate},
+		{"/api/internal/pprof/block", a.pprofBlock},
+		{"/api/internal/pprof/mutex", a.pprofMutex},
+		{"/api/internal/pprof/profile", a.pprofProfile},
+		{"/api/internal/pprof/trace", a.pprofTrace},
+	}
+
+	return lo.Map(routes, func(r struct {
+		path    string
+		handler echo.HandlerFunc
+	}, _ int) router.Route {
+		return router.NewRoute(http.MethodGet, r.path, r.handler,
+			router.WithMiddlewares(authMw),
+		)
+	})
 }
 
 func (a *API) pprofIndex(c echo.Context) error {

--- a/internal/api/pprof_routes_test.go
+++ b/internal/api/pprof_routes_test.go
@@ -26,27 +26,26 @@ func getAdminAPITestOptions() coreTesting.TestContextBuilderOption {
 	)
 }
 
-var pprofGetRoutes = []struct {
+var pprofInternalRoutes = []struct {
 	method string
 	path   string
 }{
-	{http.MethodGet, "/api/debug/pprof/cmdline"},
-	{http.MethodGet, "/api/debug/pprof/symbol"},
-	{http.MethodGet, "/api/debug/pprof/goroutine"},
-	{http.MethodGet, "/api/debug/pprof/heap"},
-	{http.MethodGet, "/api/debug/pprof/threadcreate"},
-	{http.MethodGet, "/api/debug/pprof/block"},
-	{http.MethodGet, "/api/debug/pprof/mutex"},
-	{http.MethodGet, "/api/debug/pprof/status"},
+	{http.MethodGet, "/api/internal/pprof/cmdline"},
+	{http.MethodGet, "/api/internal/pprof/symbol"},
+	{http.MethodGet, "/api/internal/pprof/goroutine"},
+	{http.MethodGet, "/api/internal/pprof/heap"},
+	{http.MethodGet, "/api/internal/pprof/threadcreate"},
+	{http.MethodGet, "/api/internal/pprof/block"},
+	{http.MethodGet, "/api/internal/pprof/mutex"},
 }
 
-// TestPprofRoutes_SharedSecret_ValidBearer verifies that every registered pprof
-// child route returns 200 when the correct bearer token is provided.
+// TestInternalPprofRoutes_ValidBearer verifies that every internal pprof
+// route returns 200 when the correct bearer token is provided.
 // profile and trace use seconds=1 to avoid long-running CPU captures.
-func TestPprofRoutes_SharedSecret_ValidBearer(t *testing.T) {
-	tests := append(pprofGetRoutes,
-		struct{ method, path string }{http.MethodGet, "/api/debug/pprof/profile?seconds=1"},
-		struct{ method, path string }{http.MethodGet, "/api/debug/pprof/trace?seconds=1"},
+func TestInternalPprofRoutes_ValidBearer(t *testing.T) {
+	tests := append(pprofInternalRoutes,
+		struct{ method, path string }{http.MethodGet, "/api/internal/pprof/profile?seconds=1"},
+		struct{ method, path string }{http.MethodGet, "/api/internal/pprof/trace?seconds=1"},
 	)
 
 	for _, r := range tests {
@@ -64,12 +63,12 @@ func TestPprofRoutes_SharedSecret_ValidBearer(t *testing.T) {
 	}
 }
 
-// TestPprofRoutes_SharedSecret_NoBearer verifies that every registered pprof
-// child route returns 401 when no bearer token is provided.
-func TestPprofRoutes_SharedSecret_NoBearer(t *testing.T) {
-	tests := append(pprofGetRoutes,
-		struct{ method, path string }{http.MethodGet, "/api/debug/pprof/profile"},
-		struct{ method, path string }{http.MethodGet, "/api/debug/pprof/trace"},
+// TestInternalPprofRoutes_NoBearer verifies that every internal pprof
+// route returns 401 when no bearer token is provided.
+func TestInternalPprofRoutes_NoBearer(t *testing.T) {
+	tests := append(pprofInternalRoutes,
+		struct{ method, path string }{http.MethodGet, "/api/internal/pprof/profile"},
+		struct{ method, path string }{http.MethodGet, "/api/internal/pprof/trace"},
 	)
 
 	for _, r := range tests {
@@ -86,12 +85,12 @@ func TestPprofRoutes_SharedSecret_NoBearer(t *testing.T) {
 	}
 }
 
-// TestPprofRoutes_SharedSecret_InvalidBearer verifies that an incorrect bearer
-// token is rejected with 401 on all pprof child routes.
-func TestPprofRoutes_SharedSecret_InvalidBearer(t *testing.T) {
-	tests := append(pprofGetRoutes,
-		struct{ method, path string }{http.MethodGet, "/api/debug/pprof/profile"},
-		struct{ method, path string }{http.MethodGet, "/api/debug/pprof/trace"},
+// TestInternalPprofRoutes_InvalidBearer verifies that an incorrect bearer
+// token is rejected with 401 on all internal pprof routes.
+func TestInternalPprofRoutes_InvalidBearer(t *testing.T) {
+	tests := append(pprofInternalRoutes,
+		struct{ method, path string }{http.MethodGet, "/api/internal/pprof/profile"},
+		struct{ method, path string }{http.MethodGet, "/api/internal/pprof/trace"},
 	)
 
 	for _, r := range tests {


### PR DESCRIPTION
Adds a separate `/api/internal/pprof/*` endpoint protected only by a shared secret (Bearer token in Authorization header). The existing `/api/debug/pprof` routes keep their JWT + ACL behavior unchanged.

**Changes:**
- Revert `buildPprofRoutes` to always use JWT + ACL (no shared secret branching)
- Add `buildInternalPprofRoutes` registering pprof handlers under `/api/internal/pprof/*` with only the shared secret middleware (no `WithAccess`, no JWT)
- Internal routes are registered only when `pprof_secret` is set in config
- Fix `GetAPIConfig` type parameter to use `*pluginConfig.APIConfig` (pointer) to match `GetConfig()` return type

**Routes registered under `/api/internal/pprof/`:**
`cmdline`, `symbol`, `goroutine`, `heap`, `threadcreate`, `block`, `mutex`, `profile`, `trace`

**Tests:** 27 tests covering all 9 routes across 3 scenarios (valid bearer, no bearer, invalid bearer) using `coreTesting.RunTestCase` pattern.

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR introduces a dedicated `/api/internal/pprof/*` endpoint for accessing Go pprof profiling data using shared secret authentication, while restoring standard JWT + admin role access control on the existing `/api/debug/pprof/*` routes.

### Key Changes

**Separation of pprof access patterns:**
- The existing `/api/debug/pprof/*` routes now always require JWT authentication and admin role access, regardless of whether a shared secret is configured. Previously, when a `PprofSecret` was set, these routes would switch to shared secret auth, bypassing normal access control.
- A new set of routes at `/api/internal/pprof/*` is registered only when `PprofSecret` is configured. These routes are authenticated exclusively via shared secret bearer token, without requiring JWT or admin role access.

**Internal pprof routes include:** `cmdline`, `symbol`, `goroutine`, `heap`, `threadcreate`, `block`, `mutex`, `profile`, and `trace`.

**Tests updated** to verify the new internal pprof routes (valid bearer, missing bearer, and invalid bearer scenarios) at the `/api/internal/pprof/*` path.

### Purpose

This change allows internal/automated services (e.g., monitoring or diagnostics tooling) to access profiling data via a shared secret without needing admin JWT credentials, while keeping the admin-facing pprof endpoints behind proper authentication and role-based access control at all times.
<!-- kody-pr-summary:end -->